### PR TITLE
optimize ztail

### DIFF
--- a/gzip_logs_tools/ztail/build.sh
+++ b/gzip_logs_tools/ztail/build.sh
@@ -1,1 +1,1 @@
-gcc -Wall -o ztail ztail.c -lz
+gcc -Wall -o ztail ztail.c -lz -O3


### PR DESCRIPTION
avoid counting the lines of the same buffers multiple times