### PR TITLE
memc-async-set: add include signal.h

### DIFF
--- a/mysql_memcached_async/mysql_memcached_async.c
+++ b/mysql_memcached_async/mysql_memcached_async.c
@@ -23,6 +23,7 @@ typedef long long longlong;
 #endif
 #include <mysql.h>
 #include <ctype.h>
+#include <signal.h>
 
 #ifdef _WIN32
 /* inet_aton needs winsock library */


### PR DESCRIPTION
required for sig_atomic_t on some platforms