### PR TITLE
gzip-tools: fix s3 signature when using temp token

### DIFF
--- a/gzip_logs_tools/common.h
+++ b/gzip_logs_tools/common.h
@@ -23,6 +23,8 @@
 #define mem_copy_str(dst, src)	mem_copy(dst, (src).data, (src).len)
 #define str_init(str)			{ sizeof(str) - 1, (char *) str }
 #define str_f(str)				(int)(str).len, (str).data
+#define str_set(str, text)                                               \
+    (str)->len = sizeof(text) - 1; (str)->data = (char *) text
 
 // typedefs
 typedef intptr_t bool_t;


### PR DESCRIPTION
x-amz-security-token must be included in the signed headers