### PR TITLE
s3grep: fix expansion on top level prefix

### DIFF
--- a/gzip_logs_tools/bin/s3grep.py
+++ b/gzip_logs_tools/bin/s3grep.py
@@ -90,9 +90,10 @@ def expand(s3, bucket_name, parts, base=[]):
             base.append(part)
             continue
 
+        prefix = ''.join(map(lambda x: x + '/', base))
         paginator = s3.get_paginator('list_objects')
         page_iterator = paginator.paginate(Bucket=bucket_name,
-            Prefix='/'.join(base) + '/', Delimiter='/')
+            Prefix=prefix, Delimiter='/')
 
         matches = []
         for page in page_iterator:


### PR DESCRIPTION
need to send Prefix='' in order to list top level folders, not
Prefix='/'