### PR TITLE
zblockgrep: capture bug fix

### DIFF
--- a/gzip_logs_tools/capture_expression.c
+++ b/gzip_logs_tools/capture_expression.c
@@ -55,12 +55,13 @@ parse_capture_expression(
 		cur->capture_index = *next++ - '1';
 		cur->data = pos;
 		cur->len = (next - 2) - pos;
-		cur++;
 
 		if (cur->capture_index > *max_capture_index)
 		{
 			*max_capture_index = cur->capture_index;
 		}
+
+		cur++;
 
 		pos = next;
 	}


### PR DESCRIPTION
cur->capture_index was used after cur was already moved to the next
item, need to cur++ only when we're done with the current item.