### PR TITLE
compressed_file: retry on curl error 77

### DIFF
--- a/gzip_logs_tools/compressed_file.c
+++ b/gzip_logs_tools/compressed_file.c
@@ -339,14 +339,33 @@ compressed_file_process(compressed_file_state_t* state)
 	CURLcode res;
 	long code;
 	long pos;
+	int i;
 
-	res = curl_easy_perform(state->curl);
-	if (res != CURLE_OK)
+	for (i = 0; ; i++)
 	{
-		if (res != CURLE_WRITE_ERROR)
+		res = curl_easy_perform(state->curl);
+		if (res == CURLE_OK)
 		{
+			break;
+		}
+
+		switch (res)
+		{
+		case CURLE_WRITE_ERROR:
+			break;
+
+		case CURLE_SSL_CACERT_BADFILE:
+			if (i < 5)
+			{
+				continue;
+			}
+
+			/* fall through */
+
+		default:
 			error(0, "%s: curl error %d - %s", state->input_url, res, curl_easy_strerror(res));
 		}
+
 		return FALSE;
 	}
 


### PR DESCRIPTION
on some servers, getting sporadic:
Problem with the SSL CA cert (path? access rights?)

it seems to be some race condition in curl/openssl initialization (sleep significantly reduces the amount of errors & running with 1 thread eliminates it completely)
empirically, retrying when getting this error works fine, added up to 5 retries on this error before giving up.